### PR TITLE
feat(package): upgrade to joi

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Version 3.2 adds the `validateProvidedData` hook, which can be very useful in va
 
 ## New in Version 3.1
 
-- 🙌 Updated to work with latest `@hapi/joi`.
+- 🙌 Updated to work with latest `joi`.
 - 🎁 Support for asynchronous validations.
 - 🚀 Support for FeathersJS V4.
 - 😎 Validate anything in the hook `context`.
@@ -33,7 +33,7 @@ yarn add @feathers-plus/validate-joi
 ## Usage Example
 
 ```js
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const validate = require('@feathers-plus/validate-joi');
 
 const name = Joi.string().trim().min(5).max(30)
@@ -141,7 +141,7 @@ The above example supposes that you have an `/faqs` service with a model that lo
 
 ```js
 // src/services/faqs/faqs.model.js
-const Joi = require('@hapi/joi')
+const Joi = require('joi')
 const { objectId } = require('@feathers-plus/validate-joi-mongodb')
 
 const attrs = {
@@ -168,7 +168,7 @@ This repo helps implement this in [Feathers](http://feathersjs.com/) CRUD
 
 ## API Reference
 
-The `joiOptions` object is passed directly to the schema, internally.  You can see all of the available options and defaults [in the @hapi/joi documentation](https://hapi.dev/family/joi/api/?v=17.1.0#anyvalidatevalue-options).  Here is a summary of the defaults:
+The `joiOptions` object is passed directly to the schema, internally.  You can see all of the available options and defaults [in the joi documentation](https://hapi.dev/family/joi/api/?v=17.1.0#anyvalidatevalue-options).  Here is a summary of the defaults:
 
 ```js
 const joiDefaults = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { HookContext } from '@feathersjs/feathers';
 
 export interface ValidateJoiOptions {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const errors = require('@feathersjs/errors');
 const utils = require('feathers-hooks-common/lib/services');
 const joiErrorsForForms = require('joi-errors-for-forms');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const pick = require('lodash/pick');
 
 // We only directly need the convert option. The others are listed for convenience.

--- a/package-lock.json
+++ b/package-lock.json
@@ -843,40 +843,10 @@
         "uberproto": "^2.0.6"
       }
     },
-    "@hapi/address": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.1.tgz",
-      "integrity": "sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-    },
     "@hapi/hoek": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-      "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
-    },
-    "@hapi/joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
-      "requires": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
-      }
-    },
-    "@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
     },
     "@hapi/topo": {
       "version": "5.0.0",
@@ -961,6 +931,24 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -1414,13 +1402,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -2975,6 +2956,18 @@
         "iterate-iterator": "^1.0.1"
       }
     },
+    "joi": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "joi-errors-for-forms": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/joi-errors-for-forms/-/joi-errors-for-forms-0.2.6.tgz",
@@ -3362,9 +3355,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node-preload": {
@@ -4503,14 +4496,11 @@
       "integrity": "sha512-68H97HffZoFaa3HFtpstahWorN9dSp5uTU6jo3GjIQ6JkJBR3hC2Nx/e/HFOoYHdUyT/Z1MRWfxN1EiQJZUyCQ=="
     },
     "uglify-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
-      "integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
+      "integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3"
-      }
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "homepage": "https://github.com/feathers-plus/validate-joi#readme",
   "dependencies": {
     "@feathersjs/errors": "^4.5.1",
-    "@hapi/joi": "^17.0.0",
     "feathers-hooks-common": "^5.0.2",
+    "joi": "^17.3.0",
     "joi-errors-for-forms": "^0.2.2",
     "lodash": "^4.17.15"
   },

--- a/test/invalid_spec.js
+++ b/test/invalid_spec.js
@@ -5,7 +5,7 @@
  prefer-arrow-callback: 0 */ /* ES5 code */
 
 const { assert } = require('chai');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const validate = require('../index');
 
 const name = Joi.string().trim().regex(/^[\sa-zA-Z0-9]{5,30}$/).required();

--- a/test/type-test.ts
+++ b/test/type-test.ts
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import validate, { ValidateJoiOptions } from '../index.js';
 
 const translations = {

--- a/test/valid_spec.js
+++ b/test/valid_spec.js
@@ -2,7 +2,7 @@
 one-var-declaration-per-line: 0, prefer-arrow-callback: 0 */ /* ES5 code */
 
 const { assert } = require('chai');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { ObjectID } = require('mongodb');
 const validate = require('../index');
 

--- a/test/validate-provided-data.test.js
+++ b/test/validate-provided-data.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { validateProvidedData: setupValidate } = require('../index');
 
 describe('validate-provided-data hook', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,38 +218,10 @@
     events "^3.1.0"
     uberproto "^2.0.6"
 
-"@hapi/address@^4.0.1":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.1.0.tgz#d60c5c0d930e77456fdcde2598e77302e2955e1d"
-  integrity sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
-"@hapi/formula@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
-  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
-
 "@hapi/hoek@^9.0.0":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"
   integrity sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
-
-"@hapi/joi@^17.0.0":
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.1.tgz#9cc8d7e2c2213d1e46708c6260184b447c661350"
-  integrity sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
-  dependencies:
-    "@hapi/address" "^4.0.1"
-    "@hapi/formula" "^2.0.0"
-    "@hapi/hoek" "^9.0.0"
-    "@hapi/pinpoint" "^2.0.0"
-    "@hapi/topo" "^5.0.0"
-
-"@hapi/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
-  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
 
 "@hapi/topo@^5.0.0":
   version "5.0.0"
@@ -273,6 +245,23 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@sideway/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"
+  integrity sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -1746,6 +1735,17 @@ joi-errors-for-forms@^0.2.2:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/joi-errors-for-forms/-/joi-errors-for-forms-0.2.6.tgz#b5aba9eb08177d8e6f46405669d208b93f20d0e6"
   integrity sha512-9jgUVquSg4mUIYOYmYauJhK3l9VeAFAWuzVVm5hNB9Y1BQ48YNVW01/ZUFLi1kP34NE5qnH4RbF0OI48kOhEEg==
+
+joi@^17.3.0:
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
+  integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Resolves #27 

I was unable to get `npm run cover` to work locally. Maybe it is something with my setup. We will see if CI/CD passes 🤞 

One option I was considering was using something like [optional](https://www.npmjs.com/package/optional) to require both `@hapi/joi` and `joi` in and then making `@hapi/joi`/`joi` a peer dependencies. That way users could use any version of `@hapi/joi`/`joi` regardless of whether they have migrated yet.